### PR TITLE
Adds back the conditional for 'DTSTART' in the setValue function

### DIFF
--- a/lib/angular-scheduler.js
+++ b/lib/angular-scheduler.js
@@ -768,6 +768,37 @@
                         }
                         scope.scheduleTimeChange();
                     }
+                    if (key === 'DTSTART') {
+                        // The form has been reset to the local zone
+                        setStartDate = true;
+                        if (/\d{8}T\d{6}.*Z/.test(value)) {
+                            // date may come in without separators. add them so new Date constructor will work
+                            value = value.replace(/(\d{4})(\d{2})(\d{2}T)(\d{2})(\d{2})(\d{2}.*$)/,
+                                function(match, p1, p2, p3, p4, p5, p6) {
+                                    return p1 + '-' + p2 + '-' + p3 + p4 + ':' + p5 + ':' + p6.substr(0, 2) + 'Z';
+                                });
+                        }
+                        if (useTimezone) {
+                            dt = new Date(value); // date adjusted to local zone automatically
+                            month = $filter('schZeroPad')(dt.getMonth() + 1, 2);
+                            day = $filter('schZeroPad')(dt.getDate(), 2);
+                            scope.schedulerStartDt = month + '/' + day + '/' + dt.getFullYear();
+                            scope.schedulerStartHour = $filter('schZeroPad')(dt.getHours(), 2);
+                            scope.schedulerStartMinute = $filter('schZeroPad')(dt.getMinutes(), 2);
+                            scope.schedulerStartSecond = $filter('schZeroPad')(dt.getSeconds(), 2);
+                            scope.scheduleTimeChange(); // calc UTC
+                        } else {
+                            // expects inbound dates to be in ISO format: 2014-04-02T00:00:00.000Z
+                            scope.schedulerStartDt = value.replace(/T.*$/, '').replace(/(\d{4})-(\d{2})-(\d{2})/, function(match, p1, p2, p3) {
+                                return p2 + '/' + p3 + '/' + p1;
+                            });
+                            timeString = value.replace(/^.*T/, '');
+                            scope.schedulerStartHour = $filter('schZeroPad')(timeString.substr(0, 2), 2);
+                            scope.schedulerStartMinute = $filter('schZeroPad')(timeString.substr(3, 2), 2);
+                            scope.schedulerStartSecond = $filter('schZeroPad')(timeString.substr(6, 2), 2);
+                        }
+                        scope.scheduleTimeChange();
+                    }
                     if (key === 'BYSETPOS') {
                         if (getValue(set, 'FREQ') === 'YEARLY') {
                             scope.yearlRepeatOption = 'other';


### PR DESCRIPTION
Connects to the last comment in https://github.com/ansible/tower/issues/1501 where a console error is posted to the console because the start time isn't parsed, because at one point in time the `DTSTART` conditional was replaced with a `TZID` conditional block. This PR simply adds the `DTSTART` conditional block back into the `setValue` function, so now we have *both* blocks of logic. 